### PR TITLE
feat: handle managed review label removal

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -6357,7 +6357,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ]],
       ["esbuild", [
         ["npm:0.9.6", {
-          "packageLocation": "./.yarn/cache/esbuild-npm-0.9.6-0d8f3502a9-418512a45d.zip/node_modules/esbuild/",
+          "packageLocation": "./.yarn/unplugged/esbuild-npm-0.9.6-0d8f3502a9/node_modules/esbuild/",
           "packageDependencies": [
             ["esbuild", "npm:0.9.6"]
           ],

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,9 +1,11 @@
 import type { Probot } from "probot";
 
 import { onLabelAdded } from "./label-added";
+import { onLabelRemoved } from "./label-removed";
 import { onPullRequestClosed } from "./pull-request-closed";
 
 export function app(app: Probot): void {
   app.on("pull_request.labeled", onLabelAdded);
+  app.on("pull_request.unlabeled", onLabelRemoved);
   app.on("pull_request.closed", onPullRequestClosed);
 }

--- a/src/label-added.ts
+++ b/src/label-added.ts
@@ -81,9 +81,9 @@ export async function onLabelAdded(
   await context.octokit.repos.createCommitStatus(
     context.repo({
       sha: headSha,
-      state: "pending",
       context: "rezensent",
       description: "blocking while in review",
+      state: "pending",
     })
   );
 

--- a/src/label-removed.ts
+++ b/src/label-removed.ts
@@ -1,0 +1,77 @@
+import type { EventTypesPayload, WebhookEvent } from "@octokit/webhooks";
+import type { Context } from "probot";
+
+import { createBotContext } from "./bot-context";
+import { getConfig } from "./config";
+import {
+  closePullRequest,
+  deleteBranch,
+  getPullRequests,
+  isReferencedPullRequest,
+  PullRequest,
+} from "./github";
+
+export async function onLabelRemoved(
+  context: EventTypesPayload["pull_request.unlabeled"] &
+    Omit<Context<any>, keyof WebhookEvent<any>>
+) {
+  const { name: label } = context.payload.label ?? {};
+  const {
+    number,
+    base: { ref: base },
+    head: { ref: head, sha: headSha },
+  } = context.payload.pull_request;
+
+  const configuration = await getConfig(context, head);
+
+  if (label !== configuration.manageReviewLabel) {
+    context.log.debug(`[PR-${number}] ignoring label`);
+    return;
+  }
+
+  context.log.debug(`[PR-${number}] Manage Review label removed`);
+
+  const botContext = createBotContext(context);
+
+  const pullRequests = await getPullRequests(botContext, {
+    params: {
+      base,
+      state: "open",
+    },
+    filters: {
+      label: configuration.teamReviewLabel,
+    },
+  });
+
+  const reviewRequests: PullRequest[] = [];
+  for (const pullRequest of pullRequests) {
+    const isReferenced = await isReferencedPullRequest(botContext, {
+      number,
+      reference: pullRequest.number,
+    });
+    if (isReferenced) {
+      reviewRequests.push(pullRequest);
+    }
+  }
+
+  context.log.debug(
+    reviewRequests.map((pr) => pr.number),
+    `[PR-${number}] found review requests`
+  );
+
+  for (const pullRequest of reviewRequests) {
+    await closePullRequest(botContext, {
+      number: pullRequest.number,
+    });
+    await deleteBranch(botContext, pullRequest.head.ref);
+  }
+
+  await context.octokit.repos.createCommitStatus(
+    context.repo({
+      sha: headSha,
+      context: "rezensent",
+      description: "removed review label",
+      state: "success",
+    })
+  );
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -2,5 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "rootDir": ".."
-  }
+  },
+  "include": ["**/*"],
+  "exclude": []
 }

--- a/test/unlabeled.test.ts
+++ b/test/unlabeled.test.ts
@@ -1,0 +1,116 @@
+import { stripIndent } from "common-tags";
+
+import { setupApp, Minutes } from "./helper";
+
+jest.setTimeout(Minutes.fifteen);
+
+test(
+  "Rezensent unlabeled workflow",
+  setupApp(async ({ logStep, gitClone, user, github }) => {
+    //----------------------------------------
+    // setup bot (labels, ...)
+    //
+
+    const managedReviewLabel = await github.createLabel({
+      name: "Rezensent: Managed Review",
+    });
+
+    const teamReviewLabel = await github.createLabel({
+      name: "Rezensent: Review Requested",
+    });
+
+    const { git } = await gitClone();
+
+    //----------------------------------------
+    //
+    logStep("Setup repo (branches, ...)");
+
+    const mainBranch = await git.createBranch("unlabeled-test");
+    await git.writeFiles({
+      ".github/CODEOWNERS": stripIndent`
+        folder-a @team-a
+        folder-b @team-b
+      `,
+      ".github/rezensent.yml": stripIndent`
+        manage-review-label: "${managedReviewLabel}"
+        team-review-label: "${teamReviewLabel}"
+      `,
+    });
+    await git.addAndPushAllChanges(mainBranch, "setup unlabeled branch");
+
+    //----------------------------------------
+    //
+    logStep("Prepare base pull request");
+
+    const changeBranch = await git.createBranch("some-changes");
+    await git.writeFiles({
+      "folder-a/a.txt": `a`,
+      "folder-b/b.txt": `b`,
+    });
+    await git.addAndPushAllChanges(changeBranch, "add some files across teams");
+
+    const basePrNumber = await github.createPullRequest({
+      base: mainBranch,
+      head: changeBranch,
+    });
+    await github.addLabel(basePrNumber, managedReviewLabel);
+    const basePr = await github.getPullRequest(basePrNumber);
+
+    //----------------------------------------
+    // wait for bot work
+    //
+    logStep("Wait for bot work");
+
+    const [splitTeamA, splitTeamB] = await Promise.all([
+      github.waitForPullRequest({
+        head: `${changeBranch}-team-a`,
+        state: "open",
+        user: user.login,
+      }),
+      github.waitForPullRequest({
+        head: `${changeBranch}-team-b`,
+        state: "open",
+        user: user.login,
+      }),
+    ]);
+
+    github.closePullRequestAfterTest(splitTeamA);
+    github.closePullRequestAfterTest(splitTeamB);
+    git.deleteBranchAfterTest(`${changeBranch}-team-a`);
+    git.deleteBranchAfterTest(`${changeBranch}-team-b`);
+
+    //----------------------------------------
+    //
+    logStep("Un-label base pr");
+
+    const splitTeamAPr = await github.getPullRequest(splitTeamA);
+    const splitTeamBPr = await github.getPullRequest(splitTeamB);
+
+    await github.removeLabel(basePrNumber, managedReviewLabel);
+
+    //----------------------------------------
+    //
+    logStep("All rezensent pull request should be closed");
+
+    await git.waitForBranchToBeDeleted(splitTeamAPr.head.ref);
+    await git.waitForBranchToBeDeleted(splitTeamBPr.head.ref);
+
+    await github.waitForPullRequest({
+      head: splitTeamAPr.head.ref,
+      state: "closed",
+    });
+
+    await github.waitForPullRequest({
+      head: splitTeamBPr.head.ref,
+      state: "closed",
+    });
+
+    await github.waitForCommitStatus(
+      { ref: basePr.head.ref },
+      {
+        context: "rezensent",
+        state: "success",
+      }
+    );
+  })
+);


### PR DESCRIPTION
When a managed review pull request is unlabeled, all still open team review pull requests should be closed and the commit status need to be set to success to allow other processes to succeed.
﻿
