### PR TITLE
fix: re-add commit status to managed pull requests

### DIFF
--- a/src/event/labeled.ts
+++ b/src/event/labeled.ts
@@ -26,6 +26,15 @@ export async function onLabelAdded(
 
   await match(context, pullRequest, {
     async managed(managed) {
+      await context.octokit.repos.createCommitStatus(
+        context.repo({
+          sha: managed.head.sha,
+          context: "rezensent",
+          description: "blocking while in review",
+          state: "pending",
+        })
+      );
+
       enqueue(
         context,
         `label added to PR-${managed.number}`,


### PR DESCRIPTION
The managed pull request commit status was removed by accident during
refactoring.

This is required to be able to block managed pull requests from being
merged.