### PR TITLE
test: update test api

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
           WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
           WEBHOOK_PROXY_URL: ${{ secrets.WEBHOOK_PROXY_URL }}
+          USER_TOKEN: ${{ secrets.USER_TOKEN }}
 
   test-result:
     runs-on: ubuntu-latest

--- a/.pnp.js
+++ b/.pnp.js
@@ -6357,7 +6357,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ]],
       ["esbuild", [
         ["npm:0.11.4", {
-          "packageLocation": "./.yarn/cache/esbuild-npm-0.11.4-294da04332-f279d903e6.zip/node_modules/esbuild/",
+          "packageLocation": "./.yarn/unplugged/esbuild-npm-0.11.4-294da04332/node_modules/esbuild/",
           "packageDependencies": [
             ["esbuild", "npm:0.11.4"]
           ],


### PR DESCRIPTION
This change splits the test api into an app part and a user part.
There are two reasons to do this:

- We can differentiate who created a PR, a comment, added a label, ...
- There are certain things only users can do and there are certain
  things only apps can do. Now we can support all of this
