### PR TITLE
fix: handle error during onboarding

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -6359,7 +6359,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ]],
       ["esbuild", [
         ["npm:0.11.5", {
-          "packageLocation": "./.yarn/cache/esbuild-npm-0.11.5-de4d11b080-d4fdb96610.zip/node_modules/esbuild/",
+          "packageLocation": "./.yarn/unplugged/esbuild-npm-0.11.5-de4d11b080/node_modules/esbuild/",
           "packageDependencies": [
             ["esbuild", "npm:0.11.5"]
           ],

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -53,7 +53,15 @@ export async function setupBot(context: Context): Promise<boolean> {
 
     return true;
   } catch {
-    await runOnboarding(context, repo, default_branch);
+    try {
+      await runOnboarding(context, repo, default_branch);
+    } catch (err) {
+      context.log.error(
+        err,
+        "[Onboarding] failed, continue without onboarding"
+      );
+      return true;
+    }
   }
   return false;
 }


### PR DESCRIPTION
In case of onboarding error, try to continue. This could either be
the onboarding was already done and we actually can continue,
or the onboarding is still open in which case the bot should skip
future work by itself.
