### PR TITLE
chore: do not fail all test if one test errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     name: test (${{ matrix.tests }})
     needs: [setup-tests]
+    continue-on-error: true
     strategy:
       matrix:
         tests: ${{ fromJson(needs.setup-tests.outputs.tests) }}


### PR DESCRIPTION
This allows actions to continue other tests if one test fails.
