### PR TITLE
refactor: update parent detection

### DIFF
--- a/src/event/closed.ts
+++ b/src/event/closed.ts
@@ -1,13 +1,9 @@
 import type { EventTypesPayload, WebhookEvent } from "@octokit/webhooks";
 import type { Context } from "probot";
-import { promisify } from "util";
-import { ErrorCode, RezensentError } from "../error";
 import { match, PullRequestBase } from "../matcher";
 import { setupBot } from "../setup";
 import { enqueue } from "../tasks/queue";
 import { synchronizeManaged } from "../tasks/synchronize-managed";
-
-const wait = promisify(setTimeout);
 
 export async function onPullRequestClosed(
   context: EventTypesPayload["pull_request.merged"] &
@@ -29,25 +25,8 @@ export async function onPullRequestClosed(
 
   await match(context, pullRequest, {
     async review(review) {
-      const handleClose = async () => {
-        const managed = await review.parent();
-        enqueue(
-          context,
-          `close ${review}`,
-          synchronizeManaged(context, managed)
-        );
-      };
-
-      try {
-        await handleClose();
-      } catch (err) {
-        RezensentError.assertInstance(err);
-        if (err.code === ErrorCode.no_parent) {
-          // let github catch-up then retry
-          await wait(1000 * 10);
-          await handleClose();
-        }
-      }
+      const managed = await review.parent();
+      enqueue(context, `close ${review}`, synchronizeManaged(context, managed));
     },
   });
 }

--- a/src/github/is-referenced.ts
+++ b/src/github/is-referenced.ts
@@ -25,9 +25,16 @@ export async function isReferencedPullRequest(
     (item) => item.event === "cross-referenced"
   );
 
-  const issues = crossReferences.filter(
-    (item) => (item as any).source.type === "issue"
+  const issues = crossReferences
+    .filter((item) => (item as any).source.type === "issue")
+    .map((item) => (item as any).source.issue.number as number);
+
+  context.log.debug(
+    {
+      issues,
+    },
+    `issues referenced in PR-${number}`
   );
 
-  return issues.some((item) => (item as any).source.issue.number === reference);
+  return issues.some((issue) => issue === reference);
 }

--- a/test/update-pr.test.ts
+++ b/test/update-pr.test.ts
@@ -150,5 +150,8 @@ test(
       "utf-8"
     );
     expect(contentB).toBe("b2");
+
+    // todo: close managed pr
+    // todo: check that all review prs get closed
   })
 );


### PR DESCRIPTION
Previously we do searched all potential open pull requests with a
managed label and then check their references. This has a lot of
drawbacks (e.g. if the managed pr is closed).

The new approach is to iterate all prs and select the first one which
has a reference to the review PR in question. This does also take
closed PRs into account and seems to be way more stable.

This may still lead to wrong detection of parent PR in some cases
(e.g. if a review PR is referenced in an unrelated PR with the same
base).
