### PR TITLE
feat: allow tasks to be canceled

### DIFF
--- a/src/github/commits.ts
+++ b/src/github/commits.ts
@@ -1,9 +1,14 @@
 import { Context } from "probot";
 
+export interface Commit {
+  sha: string;
+  author?: string;
+}
+
 export async function getPullRequestCommits(
   context: Context,
   number: number
-): Promise<{ sha: string; author?: string }[]> {
+): Promise<Commit[]> {
   return await context.octokit.paginate(
     context.octokit.pulls.listCommits,
     context.repo({

--- a/src/ownership/codeowners.ts
+++ b/src/ownership/codeowners.ts
@@ -31,10 +31,18 @@ export async function getFilePatternMapPerTeam(
   context: Context,
   { branch }: { branch: string }
 ): Promise<Map<string, string[]>> {
-  const codeowners = await getFile(context, {
-    branch,
-    path: ".github/CODEOWNERS",
-  });
+  let codeowners: string;
+  try {
+    codeowners = await getFile(context, {
+      branch,
+      path: ".github/CODEOWNERS",
+    });
+  } catch {
+    context.log.error(
+      `Failed to read '.github/CODEOWNERS'; No team patterns available`
+    );
+    return new Map();
+  }
 
   const patterns = getTeams({
     file: codeowners,

--- a/src/tasks/queue.ts
+++ b/src/tasks/queue.ts
@@ -1,57 +1,107 @@
 import { Context } from "probot";
 
+export interface CancellationToken {
+  canceled: boolean;
+  abortIfCanceled(): void;
+}
+
 export interface Task {
   readonly name: string;
   readonly number: number;
 
-  run(): Promise<void>;
+  run(token: CancellationToken): Promise<void>;
 }
 
 let queue: readonly [reason: string, task: Task][] = [];
-let current: Promise<void> | undefined;
+let current:
+  | {
+      task: Task;
+      token: CancellationToken;
+      promise: Promise<void>;
+    }
+  | undefined;
 
 export function enqueue(context: Context, reason: string, task: Task): void {
   if (current) {
-    const filtered = queue.filter(
-      (item) => !(item[1].name === task.name && item[1].number === task.number)
-    );
+    const isSame = (t1: Task, t2: Task) =>
+      t1.name === t2.name && t1.number === t2.number;
+
+    const filtered = queue.filter(([, item]) => !isSame(item, task));
     if (filtered.length < queue.length) {
       context.log.info(
-        `Queue task | [PR-${task.number}] ${task.name} | already in queue -> requeue`
+        taskMessage(task, "already in queue -> requeue", "Queue task")
       );
       queue = filtered;
     }
+    if (isSame(current.task, task)) {
+      context.log.info(
+        taskMessage(task, "cancel current task -> requeue", "Queue task")
+      );
+      current.token.canceled = true;
+    }
 
     queue = [...queue, [reason, task]];
-    context.log.info(
-      `Queue task | [PR-${task.number}] ${task.name} | ${reason}`
-    );
+    context.log.info(taskMessage(task, reason, "Queue task"));
   } else {
-    const runTask = async (reason: string, task: Task) => {
-      context.log.info(
-        `Start task | [PR-${task.number}] ${task.name} | ${reason}`
-      );
+    const runTask = async (
+      reason: string,
+      task: Task,
+      token: CancellationToken
+    ) => {
+      context.log.info(taskMessage(task, reason, "Start task"));
+
       try {
-        await task.run();
+        await task.run(token);
       } catch (err) {
-        context.log.error(err);
+        if (err === CancellationTokenImpl.signal) {
+          context.log.info(taskMessage(task, reason, "Canceled task"));
+        } else {
+          context.log.error(err);
+        }
       }
-      context.log.info(
-        `End task   | [PR-${task.number}] ${task.name} | ${reason}`
-      );
+
+      context.log.info(taskMessage(task, reason, "End task"));
     };
 
     const next = () => {
       const [item, ...rest] = queue;
       queue = rest;
+
       if (item) {
+        const token = new CancellationTokenImpl();
         const [reason, task] = item;
-        current = runTask(reason, task).then(next);
+
+        current = {
+          task,
+          token,
+          promise: runTask(reason, task, token).then(next),
+        };
       } else {
         current = undefined;
       }
     };
 
-    current = runTask(reason, task).then(next);
+    const token = new CancellationTokenImpl();
+    current = {
+      task,
+      token,
+      promise: runTask(reason, task, token).then(next),
+    };
+  }
+}
+
+function taskMessage(task: Task, reason: string, message: string): string {
+  return `${message.padEnd(14)}| [PR-${task.number}] ${task.name} | ${reason}`;
+}
+
+class CancellationTokenImpl implements CancellationToken {
+  public static signal = new Error();
+
+  public canceled = false;
+
+  public abortIfCanceled() {
+    if (this.canceled) {
+      throw CancellationTokenImpl.signal;
+    }
   }
 }


### PR DESCRIPTION
There are cases where tasks should superseded by other tasks being
scheduled (examples):

- A sync is running, because a review was merged. While this is
  executing another review is merged -> the current job can
  be canceled and superseded by a new sync task.
- A managed pr was closed -> all current updates can be deferred to
  the cleanup task.

Unfortunately it is not easily doable to use generators and types in
combination (we do want to stay typesafe here), we did implement a
cancellation token pattern.
Before each asynchronous operation a check is done if the current task
is canceled. In that case the whole job aborted.
