### PR TITLE
chore: let all action jobs run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
     strategy:
       matrix:
         tests: ${{ fromJson(needs.setup-tests.outputs.tests) }}
+      fail-fast: false
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 14.x


### PR DESCRIPTION
Even if a job fails, we should run all others to see the results
for each job and allow the cleanup to be done.
