### PR TITLE
feat: keep separate commits

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -6359,7 +6359,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ]],
       ["esbuild", [
         ["npm:0.11.6", {
-          "packageLocation": "./.yarn/cache/esbuild-npm-0.11.6-51c021bda8-8ce783c9b0.zip/node_modules/esbuild/",
+          "packageLocation": "./.yarn/unplugged/esbuild-npm-0.11.6-51c021bda8/node_modules/esbuild/",
           "packageDependencies": [
             ["esbuild", "npm:0.11.6"]
           ],

--- a/src/git.ts
+++ b/src/git.ts
@@ -33,12 +33,10 @@ export class Git {
   public async createReviewBranch({
     fromPullRequest,
     toBranch,
-    team,
     files,
   }: {
     fromPullRequest: PullRequestBase;
     toBranch: string;
-    team: string;
     files: string[];
   }): Promise<void> {
     const lastLog = async () =>
@@ -71,11 +69,7 @@ export class Git {
           // just ignore non existing files
         }
       }
-      await this.#git.commit(
-        `${message.trimEnd()}\n\n  Changes for @${team} from #${
-          fromPullRequest.number
-        }`
-      );
+      await this.#git.commit(message);
       await this.#git.add(".");
       await this.#git.commit("##rezensent##temp##");
     }

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -20,6 +20,7 @@ export interface PullRequestBase {
   readonly user: PullRequest["user"];
   readonly state: PullRequest["state"];
   readonly title: PullRequest["title"];
+  readonly body: PullRequest["body"];
   readonly labels: PullRequest["labels"][number]["name"][];
   readonly closed_at: PullRequest["closed_at"];
   readonly merged_at: PullRequest["merged_at"];

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -1,0 +1,56 @@
+export function removeIndentation(
+  input: string | TemplateStringsArray,
+  ...values: unknown[]
+): string {
+  let text: string;
+  if (typeof input === "string") {
+    text = input;
+  } else {
+    let i = 0;
+    const combined = [input[i]];
+    while (true) {
+      if (i >= values.length) {
+        break;
+      }
+      combined.push(String(values[i]));
+      i++;
+      if (i >= input.length) {
+        break;
+      }
+      combined.push(input[i]);
+    }
+    text = combined.join("");
+  }
+
+  const lines = text.split("\n");
+
+  const indentation = lines
+    .filter((line): line is string => line.trim().length > 0)
+    .map((line) => /(^\s*)/.exec(line))
+    .filter((matcher): matcher is RegExpExecArray => Boolean(matcher))
+    .map((matcher) => matcher[1])
+    .filter((prefix): prefix is string => Boolean(prefix))
+    .reduce(
+      (shortest, prefix) =>
+        prefix.length < shortest ? prefix.length : shortest,
+      Number.MAX_SAFE_INTEGER
+    );
+
+  if (indentation === Number.MAX_SAFE_INTEGER) {
+    return text;
+  }
+
+  const first = lines[0];
+  const last = lines[lines.length - 1];
+  const middle = lines.slice(1, lines.length - 1);
+
+  const newLines = middle;
+  if (first && first.trim().length > 0) {
+    newLines.unshift(first);
+  }
+  if (last && last.trim().length > 0) {
+    newLines.push(last);
+  }
+
+  return newLines.map((line) => line.substr(indentation)).join("\n");
+}

--- a/test/happy-path.test.ts
+++ b/test/happy-path.test.ts
@@ -50,7 +50,11 @@ test(
       "folder-a/a.txt": `a`,
       "folder-b/b.txt": `b`,
     });
-    await git.addAndPushAllChanges(changeBranch, "add some files across teams");
+    await git.addAndCommitChanges("add some files across teams");
+    await git.writeFiles({
+      "folder-a/c.txt": `c`,
+    });
+    await git.addAndPushAllChanges(changeBranch, "further changes");
 
     const managedPrNumber = await userGithub.createPullRequest({
       base: mainBranch,

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -400,6 +400,7 @@ export type TestRunner = {
       writeFiles(files: { [path: string]: string }): Promise<void>;
 
       push(branch: string): Promise<void>;
+      addAndCommitChanges(message: string): Promise<void>;
       addAndPushAllChanges(branch: string, message: string): Promise<void>;
     };
   }>;
@@ -854,6 +855,13 @@ export async function pushBranch(
   await git.push(["origin", testify(branch, testId, branchPattern)]);
 }
 
+export async function addAndCommitChanges(
+  { git }: SimpleGitTaskContext,
+  message: string
+): Promise<void> {
+  await git.add(["."]).commit(message);
+}
+
 export async function addAndPushAllChanges(
   git: SimpleGit,
   testId: string,
@@ -1082,6 +1090,8 @@ export function setupApp(
               writeFiles: (files) => writeFiles(directory, files),
 
               push: (branch) => pushBranch(git, testId, branch),
+              addAndCommitChanges: (message) =>
+                addAndCommitChanges({ git, testId, log }, message),
               addAndPushAllChanges: (branch, message) =>
                 addAndPushAllChanges(git, testId, branch, message),
             };

--- a/test/strings.test.ts
+++ b/test/strings.test.ts
@@ -1,0 +1,19 @@
+import { removeIndentation } from "../src/strings";
+
+test.each([
+  [`abc`, "abc"],
+  [`abc\nabc`, "abc\nabc"],
+  [`\n    abc\n    abc\n  `, "abc\nabc"],
+  [`\n    abc\n\n    abc\n  `, "abc\n\nabc"],
+  [`\n      abc\n\n    abc\n  `, "  abc\n\nabc"],
+])("Should remove leading indentation from the given text", (text, result) => {
+  expect(removeIndentation(text)).toBe(result);
+});
+
+test("Should remove leading indentation when used as tagged template string", () => {
+  expect(removeIndentation`\n      abc\n\n    abc\n  `).toBe("  abc\n\nabc");
+
+  const a = "abc";
+  const b = 123;
+  expect(removeIndentation`\n      ${a}\n\n    ${b}\n  `).toBe("  abc\n\n123");
+});

--- a/test/update-pr.test.ts
+++ b/test/update-pr.test.ts
@@ -53,7 +53,16 @@ test(
       "folder-a/a.txt": `a`,
       "folder-b/b.txt": `b`,
     });
-    await git.addAndPushAllChanges(changeBranch, "add some files across teams");
+    await git.addAndCommitChanges("add some files across teams");
+    await git.writeFiles({
+      "folder-a/c.txt": `a`,
+      "folder-b/b.txt": `not-b`,
+      "folder-b/d.txt": `d`,
+    });
+    await git.addAndPushAllChanges(
+      changeBranch,
+      "some more changed files across teams"
+    );
 
     const managedPrNumber = await userGithub.createPullRequest({
       base: mainBranch,


### PR DESCRIPTION
This will keep the separate commits added to the managed pull request.
We do this to maintain the understandability of the commit history.
