### PR TITLE
fix: add git binary to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:15-alpine
 
+RUN apk add git
+
 USER node
 WORKDIR /app
 


### PR DESCRIPTION
Since we are using git to communicate with github we need it
installed in our environment
