### PR TITLE
refactor: use substring instead of substr

### DIFF
--- a/src/ownership/codeowners.ts
+++ b/src/ownership/codeowners.ts
@@ -6,7 +6,7 @@ export function getTeams({ file }: { file: string }): string[] {
     file.split(/\n/).reduce((set, line) => {
       const [_, team] = line.split(/\s+/);
       if (team && team.startsWith("@")) {
-        set.add(team.substr(1));
+        set.add(team.substring(1));
       }
       return set;
     }, new Set<string>())
@@ -23,7 +23,7 @@ export function getPatternsByTeam({
   return file
     .split(/\n/)
     .map((line) => line.split(/\s+/))
-    .filter(([, t]) => t?.startsWith("@") && t.substr(1) === team)
+    .filter(([, t]) => t?.startsWith("@") && t.substring(1) === team)
     .map(([path]) => (path === "*" ? "^.*$" : `^${path}.*$`));
 }
 

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -52,5 +52,5 @@ export function removeIndentation(
     newLines.push(last);
   }
 
-  return newLines.map((line) => line.substr(indentation)).join("\n");
+  return newLines.map((line) => line.substring(indentation)).join("\n");
 }

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -262,7 +262,7 @@ function testify(str: string, testId: string, test: string): string {
   const regexp = new RegExp(pattern);
 
   if (str.startsWith("origin/")) {
-    return `origin/${testify(str.substr("origin/".length), testId, test)}`;
+    return `origin/${testify(str.substring("origin/".length), testId, test)}`;
   }
   return regexp.test(str) ? str : test.replace("%s", str).replace("%t", testId);
 }


### PR DESCRIPTION
Some tools issue a warning now for use of `substr`, e.g. [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) has this:

> Deprecated: This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes. Avoid using it, and update existing code if possible; [...] Be aware that this feature may cease to work at any time.

Even though it still works everywhere, I think it could be irritating and especially when there's only one parameter it can be easily replaced with [`substring`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring).